### PR TITLE
Bugfix Workflow Module properties

### DIFF
--- a/src/main/java/io/vanillabp/springboot/modules/WorkflowModulePropertiesConfiguration.java
+++ b/src/main/java/io/vanillabp/springboot/modules/WorkflowModulePropertiesConfiguration.java
@@ -35,18 +35,19 @@ public class WorkflowModulePropertiesConfiguration {
         for (final var module : modules) {
             
             // add e.g. taxiRide.yml or taxiRide.yaml
-            if (!addYaml(resources, module.getWorkflowModuleId())) {
+            if (!addYaml(resources, module.getWorkflowModuleId(), module.getWorkflowModuleId())) {
                 // or taxi-ride.yml or taxi-ride.yaml
-                addYaml(resources,
+                addYaml(resources, module.getWorkflowModuleId(),
                         CaseUtils.camelToKebap(module.getWorkflowModuleId()));
             }
 
             for (final var profile : environment.getActiveProfiles()) {
 
                 // add e.g. taxiRide-local.yml or taxiRide-local.yaml
-                if (!addYaml(resources, module.getWorkflowModuleId() + "-" + profile)) {
+                if (!addYaml(resources, module.getWorkflowModuleId(),
+                        module.getWorkflowModuleId() + "-" + profile)) {
                     // or taxi-ride-local.yml or taxi-ride-local.yaml
-                    addYaml(resources,
+                    addYaml(resources, module.getWorkflowModuleId(),
                             CaseUtils.camelToKebap(module.getWorkflowModuleId()) + "-" + profile);
                 }
 
@@ -67,11 +68,10 @@ public class WorkflowModulePropertiesConfiguration {
 
     private static boolean addYaml(
             final LinkedList<Resource> resources,
-            final String directory,
-            final String formatedWorkflowModuleId) {
+            final String pathAndFilename) {
 
         final var defaultsYaml = new ClassPathResource(
-                directory + formatedWorkflowModuleId + ".yaml");
+                pathAndFilename + ".yaml");
         if (defaultsYaml.exists()) {
             logger.debug("Adding yaml-file: {}", defaultsYaml.getDescription());
             resources.add(defaultsYaml);
@@ -79,7 +79,7 @@ public class WorkflowModulePropertiesConfiguration {
         }
         
         final var defaultsYml = new ClassPathResource(
-                directory + formatedWorkflowModuleId + ".yml");
+                pathAndFilename + ".yml");
         if (defaultsYml.exists()) {
             logger.debug("Adding yaml-file: {}", defaultsYml.getDescription());
             resources.add(defaultsYml);
@@ -92,18 +92,19 @@ public class WorkflowModulePropertiesConfiguration {
 
     private static boolean addYaml(
             final LinkedList<Resource> resources,
-            final String formatedWorkflowModuleId) {
+            final String directory,
+            final String formattedWorkflowModuleIdWithProfile) {
 
-        if (addYaml(resources, "", formatedWorkflowModuleId)) {
+        if (addYaml(resources, formattedWorkflowModuleIdWithProfile)) {
             return true;
         }
-        if (addYaml(resources, "config/", formatedWorkflowModuleId)) {
+        if (addYaml(resources, "config/" + formattedWorkflowModuleIdWithProfile)) {
             return true;
         }
-        if (addYaml(resources, formatedWorkflowModuleId + "/", formatedWorkflowModuleId)) {
+        if (addYaml(resources, directory + "/" + formattedWorkflowModuleIdWithProfile)) {
             return true;
         }
-        if (addYaml(resources, formatedWorkflowModuleId + "/config/", formatedWorkflowModuleId)) {
+        if (addYaml(resources, directory + "/config/" + formattedWorkflowModuleIdWithProfile)) {
             return true;
         }
         return false;

--- a/src/main/java/io/vanillabp/springboot/utils/JpaSpringDataUtilConfiguration.java
+++ b/src/main/java/io/vanillabp/springboot/utils/JpaSpringDataUtilConfiguration.java
@@ -13,6 +13,8 @@ import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 @ConditionalOnMissingBean(SpringDataUtil.class)
 public class JpaSpringDataUtilConfiguration {
 
+    public static final String BEANNAME_SPRINGDATAUTIL = "jpaSpringDataUtil";
+
     @Autowired
     private ApplicationContext applicationContext;
 
@@ -22,7 +24,7 @@ public class JpaSpringDataUtilConfiguration {
     @Autowired
     private JpaContext jpaContext;
     
-    @Bean
+    @Bean(name = BEANNAME_SPRINGDATAUTIL)
     public SpringDataUtil jpaSpringDataUtil() {
        
         return new JpaSpringDataUtil(


### PR DESCRIPTION
Workflow modules properties for profiles were not loaded if placed in a sub-directory named like the workflow module id:

1. `config/myworkflowmodule-myspringprofile.yaml` worked
1. `myworkflowmodule/config/myworkflowmodule-myspringprofile.yaml` did not work